### PR TITLE
Static kan ikke brukes uten kontekst

### DIFF
--- a/controller/layout.controller.php
+++ b/controller/layout.controller.php
@@ -43,4 +43,4 @@ if ( !get_option('pl_id')) {
     UKMdeltakere::addViewData('nominasjoner', $nominasjoner);
 }
 
-UKMdeltakere::addViewData('action', static::getAction());
+UKMdeltakere::addViewData('action', UKMdeltakere::getAction());


### PR DESCRIPTION
Kall på statisk metode ved bruk av 'static' uten kontekst blir ikke mulig på PHP8, derfor ble er det definert klasse hvor den statiske metoden finnes